### PR TITLE
feat: button-component, added functionality for Invert buttons, large, medium, small and dynamic Sizing

### DIFF
--- a/public/assets/icons/iconoir_cancel.svg
+++ b/public/assets/icons/iconoir_cancel.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12.001 12.5001L17.244 17.7431M6.758 17.7431L12.001 12.5001L6.758 17.7431ZM17.244 7.25708L12 12.5001L17.244 7.25708ZM12 12.5001L6.758 7.25708L12 12.5001Z" stroke="#2A3647" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.001 12.5001L17.244 17.7431M6.758 17.7431L12.001 12.5001L6.758 17.7431ZM17.244 7.25708L12 12.5001L17.244 7.25708ZM12 12.5001L6.758 7.25708L12 12.5001Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/app/features/contacts-page/components/add-contact-modal/add-contact-modal.component.html
+++ b/src/app/features/contacts-page/components/add-contact-modal/add-contact-modal.component.html
@@ -43,11 +43,11 @@
           </div>
 
           <div class="modal-buttons">
-            <app-button iconSrc="assets/icons/iconoir_cancel.svg" altText="Cancel" [fontSize]="'16px'" (btnClick)="closeModal()" [invert]="true">
+            <app-button iconSrc="assets/icons/iconoir_cancel.svg" altText="Cancel" [fontSize]="'16px'" (btnClick)="closeModal()" [invert]="true" [size]="'large'">
               Cancel
             </app-button>
 
-            <app-button iconSrc="assets/icons/check.svg" altText="Create" [fontSize]="'16px'"
+            <app-button iconSrc="assets/icons/check.svg" altText="Create" [fontSize]="'16px'" [size]="'large'"
               (btnClick)="createContact()">
               Create Contact
             </app-button>

--- a/src/app/shared/ui/button/button.component.html
+++ b/src/app/shared/ui/button/button.component.html
@@ -1,9 +1,10 @@
 <button [type]="type" class="add-contact-button" (click)="handleClick()" [class]="{ invert: invert }"
-  [class.large]="size === 'large'" [class.medium]="size === 'medium'" [class.small]="size === 'small'"
+  [class.large]="size === 'large'" [class.medium]="size === 'medium'" [class.small]="size === 'small'" [class.dynamic]="size === 'dynamic'" 
   [ngStyle]="{ 'font-size': fontSize }">
 
   <span>
     <ng-content></ng-content>
   </span>
-  <img [src]="iconSrc" [alt]="altText" class="icon">
+  <div [innerHTML]="svgContent" class="icon" [ngClass]="invert ? 'icon-invert' : ''"></div>
+  
 </button>

--- a/src/app/shared/ui/button/button.component.scss
+++ b/src/app/shared/ui/button/button.component.scss
@@ -1,7 +1,5 @@
 @use './../../../../styles/variables.scss' as *;
 
-
-
 .add-contact-button {
   background-color: $color-primary;
   color: $color-white;
@@ -13,7 +11,6 @@
   justify-content: center;
   gap: 8px;
   border-radius: 8px;
-  height: 56px;
   font-weight: 600;
   cursor: pointer;
   box-sizing: border-box;
@@ -24,12 +21,15 @@
 }
 
 .icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 32px;
   height: 32px;
+}
 
-  svg {
-      color: aqua !important;
-  }
+.icon-invert {
+  stroke: $color-primary;
 }
 
 .invert {
@@ -40,5 +40,30 @@
   &:hover {
     color: $color-primary-hover;
     border-color: $color-primary-hover;
+
+    .icon-invert {
+      stroke: $color-primary-hover;
+    }
   }
+}
+
+.small {
+  height: 42px;
+  max-width: 180px;
+}
+
+.medium {
+  height: 56px;
+  min-width: 180px;
+  max-width: 280px;
+}
+
+.large {
+  height: 56px;
+  min-width: 100%;
+  max-width: 420px;
+}
+
+.dynamic {
+  width: 100%;
 }

--- a/src/app/shared/ui/button/button.component.ts
+++ b/src/app/shared/ui/button/button.component.ts
@@ -1,26 +1,43 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { SVGInlineService } from '../../services/svg-inline.service';
+import { HttpClientModule } from '@angular/common/http';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-button',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, HttpClientModule],
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
+  providers: [SVGInlineService]
 })
 
 export class ButtonComponent {
+  svgContent!: SafeHtml;
+
   @Input() iconSrc!: string;
   @Input() altText: string = 'Button icon';
   @Input() type: string = 'button';
   @Input() fontSize: string = '26px';
-  @Input() size: 'large' | 'medium' | 'small' = 'medium';
-  @Input() invert: boolean = false; 
+  @Input() size: 'large' | 'medium' | 'small' | 'dynamic' = 'dynamic';
+  @Input() invert: boolean = false;
 
 
   @Output() btnClick = new EventEmitter<void>();
 
+  constructor(private svgService: SVGInlineService, private sanitizer: DomSanitizer) { }
+
   handleClick() {
     this.btnClick.emit();
+  }
+
+  ngOnInit(): void {
+    this.svgService.getInlineSVG(this.iconSrc).subscribe({
+      next: (svg: string) => {
+        this.svgContent = this.sanitizer.bypassSecurityTrustHtml(svg);
+      },
+      error: err => console.error('SVG load error:', err)
+    });
   }
 }


### PR DESCRIPTION
Modified the button-component, so it can generate inverted buttons. 

Utilized svg-inline service to convert the SVG inside the buttons to inline SVG code.
So likely the inline SVG code is rendered into the DOM instead of the SVG image itself.

This is done to manipulate the SVG stroke color on hover via CSS.